### PR TITLE
Upgrade arrow_path to version 3.1.0

### DIFF
--- a/lib/graphite_edges_painter.dart
+++ b/lib/graphite_edges_painter.dart
@@ -186,11 +186,16 @@ Path _defaultEdgePathBuilder(
   if (style.arrowType == EdgeArrowType.none) {
     return styledPath;
   }
-  return ArrowPath.make(
-      path: styledPath,
-      isDoubleSided: style.arrowType == EdgeArrowType.both,
-      tipLength: style.tipLength,
-      tipAngle: style.tipAngle);
+
+  var arrowPath = ArrowPath.addTip(styledPath,
+      tipLength: style.tipLength, tipAngle: style.tipAngle);
+
+  if (style.arrowType == EdgeArrowType.both) {
+    arrowPath = ArrowPath.addTip(arrowPath,
+        tipLength: style.tipLength, tipAngle: style.tipAngle, isBackward: true);
+  }
+
+  return arrowPath;
 }
 
 List<Offset> _smoothCorners(List<Offset> points, double radius) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: "direct main"
     description:
       name: arrow_path
-      sha256: "07194a2f165242543e81b7fb16d86d433b52ee31adb0dc9afe9273c0a45e2d9e"
+      sha256: "794651f27eca2e9b4749d307b1e7fb8254fb8343124cc24ee6497f3ceff94651"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.1.0"
   async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   touchable: ^1.0.2
-  arrow_path: ^2.0.0
+  arrow_path: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I hope this PR finds you well and safe.

## Migration to 3.1.0
ArrowPath.make() is now deprecated, we need to use ArrowPath.addTip() instead.
If we are not using the `isDoubleSided` argument of ArrowPath.make() then we can safely replace it by ArrowPath.addTip() without any other change.

But we are using the `isDoubleSided` argument of ArrowPath.make() then we need to change the code like this:

Before:
```dart
  Path path = Path();
  path.relativeLineTo(100, 100);
  path = ArrowPath.make(path, isDoubleSided: true);
```

After:
```dart
  Path path = Path();
  path.relativeLineTo(100, 100);
  path = ArrowPath.addTip(path);
  path = ArrowPath.addTip(path, isBackward: true);
```

Thank you for reviewing this contribution when you have the opportunity.