### PR TITLE
fix: Setting the EdgeInput type to EdgeArrowType.both has no effect #35

### DIFF
--- a/lib/graphite_edges_painter.dart
+++ b/lib/graphite_edges_painter.dart
@@ -7,7 +7,7 @@ import 'package:graphite/graphite_typings.dart';
 import 'package:touchable/touchable.dart';
 
 EdgeStyle _defaultStyleBuilder(Edge edge) {
-  return EdgeStyle();
+  return EdgeStyle(arrowType: edge.arrowType);
 }
 
 class LinesPainter extends CustomPainter {


### PR DESCRIPTION
fix #35 

This pull request includes a change to the `lib/graphite_edges_painter.dart` file to fix the `EdgeStyle` initialization by utilizing the `arrowType` property from the `Edge` object.

Codebase improvement:

* [`lib/graphite_edges_painter.dart`](diffhunk://#diff-4aac51ecd0ebc682409c67993d6a34c032f1d69e99ec9889ab692831db7d21d1L10-R10): Modified the `_defaultStyleBuilder` function to return an `EdgeStyle` with the `arrowType` property set to the `arrowType` of the provided `Edge` object.